### PR TITLE
Updating default listen port

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Command-line options: (Only `-ntp.server` is required.)
   -version
         Print version information.
   -web.listen-address string
-        Address on which to expose metrics and web interface. (default ":9100")
+        Address on which to expose metrics and web interface. (default ":9558")
   -web.telemetry-path string
         Path under which to expose metrics. (default "/metrics")
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Command-line options: (Only `-ntp.server` is required.)
   -version
         Print version information.
   -web.listen-address string
-        Address on which to expose metrics and web interface. (default ":9558")
+        Address on which to expose metrics and web interface. (default ":9559")
   -web.telemetry-path string
         Path under which to expose metrics. (default "/metrics")
 ```

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var version string // will be substituted at compile-time
 func main() {
 	var (
 		showVersion        = flag.Bool("version", false, "Print version information.")
-		listenAddress      = flag.String("web.listen-address", ":9558", "Address on which to expose metrics and web interface.")
+		listenAddress      = flag.String("web.listen-address", ":9559", "Address on which to expose metrics and web interface.")
 		metricsPath        = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		ntpServer          = flag.String("ntp.server", "", "NTP server to use (required).")
 		ntpProtocolVersion = flag.Int("ntp.protocol-version", 4, "NTP protocol version to use.")

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var version string // will be substituted at compile-time
 func main() {
 	var (
 		showVersion        = flag.Bool("version", false, "Print version information.")
-		listenAddress      = flag.String("web.listen-address", ":9100", "Address on which to expose metrics and web interface.")
+		listenAddress      = flag.String("web.listen-address", ":9558", "Address on which to expose metrics and web interface.")
 		metricsPath        = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		ntpServer          = flag.String("ntp.server", "", "NTP server to use (required).")
 		ntpProtocolVersion = flag.Int("ntp.protocol-version", 4, "NTP protocol version to use.")


### PR DESCRIPTION
Current listen port (`9100`) clashes with `node_exporter`.

I've also registered the new (`9559`) port under ["Default port allocations" wiki](https://github.com/prometheus/prometheus/wiki/Default-port-allocations#exporters-starting-at-9100) to make sure there will not be any conflicts with some other exporters in the future.