### PR TITLE
Include NTP server name as label

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -31,11 +31,11 @@ import (
 )
 
 var (
-	drift = prometheus.NewGauge(prometheus.GaugeOpts{
+	drift = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "ntp",
 		Name:      "drift_seconds",
 		Help:      "Difference between system time and NTP time.",
-	})
+	}, []string{"server"})
 	stratum = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "ntp",
 		Name:      "stratum",
@@ -105,7 +105,7 @@ func (c Collector) measure() error {
 		strat = calculateMedian(measurementsStratum)
 	}
 
-	drift.Set(clockOffset)
+	drift.WithLabelValues(c.NtpServer).Set(clockOffset)
 	stratum.Set(strat)
 
 	scrapeDuration.Observe(time.Since(begin).Seconds())


### PR DESCRIPTION
Metric `ntp_drift_seconds` now includes `server` label, which identifies the NTP server the drift is being checked with.

This is useful in dashboards and alerts (so we know what exactly we were checking) and it can be used if in the future we would support checking the drift with multiple servers (something requested via #2).