### PR TITLE
Make the measurement duration configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,23 @@ make GOLDFLAGS="-w -linkmode external -extldflags -static" && docker build .
 
 ## Usage
 
-Command-line options: (Only `--ntp.server` is required.)
+Command-line options: (Only `-ntp.server` is required.)
 
 ```plain
-  --log.format value
+  -log.format value
         Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true" (default "logger:stderr")
-  --log.level value
+  -log.level value
         Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] (default "info")
-  --ntp.protocol-version int
+  -ntp.protocol-version int
         NTP protocol version to use. (default 4)
-  --ntp.server string
+  -ntp.server string
         NTP server to use (required).
-  --ntp.measurement-duration duration
+  -ntp.measurement-duration duration
         Repeat the measurements for the specified duration and calculate median in case the drift is unusually high (>10ms). (default 30s)
-  --version
+  -version
         Print version information.
-  --web.listen-address string
+  -web.listen-address string
         Address on which to expose metrics and web interface. (default ":9559")
-  --web.telemetry-path string
+  -web.telemetry-path string
         Path under which to expose metrics. (default "/metrics")
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ make
 ```
 
 The binary can also be installed with `go get`:
+
 ```bash
 go get github.com/sapcc/ntp_exporter
 ```
@@ -24,22 +25,23 @@ make GOLDFLAGS="-w -linkmode external -extldflags -static" && docker build .
 
 ## Usage
 
-Command-line options: (Only `-ntp.server` is required.)
+Command-line options: (Only `--ntp.server` is required.)
 
-```
-  -log.format value
+```plain
+  --log.format value
         Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true" (default "logger:stderr")
-  -log.level value
+  --log.level value
         Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] (default "info")
-  -ntp.protocol-version int
+  --ntp.protocol-version int
         NTP protocol version to use. (default 4)
-  -ntp.server string
+  --ntp.server string
         NTP server to use (required).
-  -version
+  --ntp.measurement-duration duration
+        Repeat the measurements for the specified duration and calculate median in case the drift is unusually high (>10ms). (default 30s)
+  --version
         Print version information.
-  -web.listen-address string
+  --web.listen-address string
         Address on which to expose metrics and web interface. (default ":9559")
-  -web.telemetry-path string
+  --web.telemetry-path string
         Path under which to expose metrics. (default "/metrics")
 ```
-

--- a/collector.go
+++ b/collector.go
@@ -50,8 +50,9 @@ var (
 
 //Collector implements the prometheus.Collector interface.
 type Collector struct {
-	NtpServer          string
-	NtpProtocolVersion int
+	NtpServer              string
+	NtpProtocolVersion     int
+	NtpMeasurementDuration time.Duration
 }
 
 //Describe implements the prometheus.Collector interface.
@@ -89,7 +90,7 @@ func (c Collector) measure() error {
 		var measurementsClockOffset []float64
 		var measurementsStratum []float64
 
-		for time.Since(begin).Seconds() < 30 {
+		for time.Since(begin) < c.NtpMeasurementDuration {
 			clockOffset, stratum, err := c.getClockOffsetAndStratum()
 
 			if err != nil {

--- a/collector.go
+++ b/collector.go
@@ -77,19 +77,21 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c Collector) measure() error {
-	begin := time.Now()
+	const highDrift = 0.01
 
+	begin := time.Now()
 	clockOffset, strat, err := c.getClockOffsetAndStratum()
 
 	if err != nil {
 		return fmt.Errorf("couldn't get NTP drift: %s", err)
 	}
 
-	//if clock drift is unusually high (>10ms): repeat measurements for 30 seconds and submit median value
-	if clockOffset > 0.01 {
+	//if clock drift is unusually high (e.g. >10ms): repeat measurements for 30 seconds and submit median value
+	if clockOffset > highDrift {
 		var measurementsClockOffset []float64
 		var measurementsStratum []float64
 
+		log.Warnf("clock drift is above %.2fs, taking multiple measurements for %.2f seconds", highDrift, c.NtpMeasurementDuration.Seconds())
 		for time.Since(begin) < c.NtpMeasurementDuration {
 			clockOffset, stratum, err := c.getClockOffsetAndStratum()
 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -35,11 +36,12 @@ var version string // will be substituted at compile-time
 
 func main() {
 	var (
-		showVersion        = flag.Bool("version", false, "Print version information.")
-		listenAddress      = flag.String("web.listen-address", ":9559", "Address on which to expose metrics and web interface.")
-		metricsPath        = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-		ntpServer          = flag.String("ntp.server", "", "NTP server to use (required).")
-		ntpProtocolVersion = flag.Int("ntp.protocol-version", 4, "NTP protocol version to use.")
+		showVersion            = flag.Bool("version", false, "Print version information.")
+		listenAddress          = flag.String("web.listen-address", ":9559", "Address on which to expose metrics and web interface.")
+		metricsPath            = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+		ntpServer              = flag.String("ntp.server", "", "NTP server to use (required).")
+		ntpProtocolVersion     = flag.Int("ntp.protocol-version", 4, "NTP protocol version to use.")
+		ntpMeasurementDuration = flag.Duration("ntp.measurement-duration", 30*time.Second, "Duration of measurements in case of high (>10ms) drift.")
 	)
 	flag.Parse()
 
@@ -56,7 +58,7 @@ func main() {
 	}
 
 	log.Infoln("Starting ntp_exporter", version)
-	prometheus.MustRegister(Collector{*ntpServer, *ntpProtocolVersion})
+	prometheus.MustRegister(Collector{*ntpServer, *ntpProtocolVersion, *ntpMeasurementDuration})
 	handler := promhttp.HandlerFor(prometheus.DefaultGatherer,
 		promhttp.HandlerOpts{ErrorLog: log.NewErrorLogger()})
 

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 		log.Fatalf("invalid NTP protocol version %d; must be 2, 3, or 4", *ntpProtocolVersion)
 	}
 
-	log.Infoln("Starting ntp_exporter", version)
+	log.Infoln("starting ntp_exporter", version)
 	prometheus.MustRegister(Collector{*ntpServer, *ntpProtocolVersion, *ntpMeasurementDuration})
 	handler := promhttp.HandlerFor(prometheus.DefaultGatherer,
 		promhttp.HandlerOpts{ErrorLog: log.NewErrorLogger()})
@@ -73,7 +73,7 @@ func main() {
 			</html>`))
 	})
 
-	log.Infoln("Listening on", *listenAddress)
+	log.Infoln("listening on", *listenAddress)
 	err := http.ListenAndServe(*listenAddress, nil)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
PR #3 introduced a static `30s` duration to repeat measurements for in case the current time drift is above `10ms`. Anyhow, `30s` duration does not work well in case when we have Prometheus scrape timeout configured to a smaller number (e.g. `10s`). In this case, the scrape timeouts, without getting results from the exporter.

This PR allows to override (still keeping `30s` as default to avoid breaking existing setups) this measurement duration, allowing to reduce it to align it with Prometheus scrape timeout.

I've named the setting `--ntp.measurement-duration`, but please let me know if you think there's a better name for it 🙂 

I've also added additional `warning` log message in case the drift was to high and multiple measurements were requires, so it's easier to indicate that's the case and know the exact values of `high drift` and `measurement duration`.