### PR TITLE
Changed mode-2 parameter 'server' to 'target'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ When the option `-ntp.source http` is specified, the NTP server and connection
 options are obtained from the query parameters on each `GET /metrics` HTTP
 request:
 
-- `server`: NTP server to use
+- `target`: NTP server to use
 - `protocol`: NTP protocol version (2, 3 or 4)
 - `duration`: duration of measurements in case of high drift
 
 For example:
 
 ```sh
-$ curl 'http://localhost:9559/metrics?server=ntp.example.com&protocol=4&duration=10s'
+$ curl 'http://localhost:9559/metrics?target=ntp.example.com&protocol=4&duration=10s'
 ```
 
 ## Frequently asked questions (FAQ)

--- a/collector.go
+++ b/collector.go
@@ -30,9 +30,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func CollectorInitial(server string, protocol int, duration time.Duration) Collector {
+func CollectorInitial(target string, protocol int, duration time.Duration) Collector {
 	return Collector{
-		NtpServer:              server,
+		NtpServer:              target,
 		NtpProtocolVersion:     protocol,
 		NtpMeasurementDuration: duration,
 		drift: prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/main.go
+++ b/main.go
@@ -93,14 +93,14 @@ func handlerMetrics(w http.ResponseWriter, r *http.Request) {
 	d := ntpMeasurementDuration
 
 	if ntpSource == "http" {
-		for _, i := range []string{"server", "protocol", "duration"} {
+		for _, i := range []string{"target", "protocol", "duration"} {
 			if r.URL.Query().Get(i) == "" {
 				http.Error(w, fmt.Sprintf("Get parameter is empty: %s", i), http.StatusBadRequest)
 				return
 			}
 		}
 
-		s = r.URL.Query().Get("server")
+		s = r.URL.Query().Get("target")
 
 		if v, err := strconv.ParseInt(r.URL.Query().Get("protocol"), 10, 32); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
According to "MULTI-TARGET EXPORTER PATTERN" (https://prometheus.io/docs/guides/multi-target-exporter/) we should use parameter target to be able to use scrape config like Blackbox exporter use. Currently, we have a parameter server, which has the same purpose. I renamed it to target. Now it is possible to have standard scrape config for multi-target probing.

```
- job_name: ntp
  metrics_path: /probe
  params:
    protocol: [4]
    duration: [10s]
  static_configs:
    - targets:
      - a.b.c.d
      - e.f.g.h
```

However, this change is backward incompatible, so exporter version should be bumped to 2.x.x to follow semantic naming convention