### PR TITLE
Add ntp_build_info metric with version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ of that node's clock against a given NTP server or servers.
 
 These are the metrics supported.
 
+- `ntp_build_info`
 - `ntp_drift_seconds`
 - `ntp_stratum`
 - `ntp_rtt_seconds`

--- a/main.go
+++ b/main.go
@@ -46,8 +46,11 @@ var (
 
 var logger = log.New(os.Stderr, "", log.LstdFlags)
 
+var version = bininfo.VersionOr("unknown")
+var buildDate = bininfo.BuildDateOr("unknown")
+var revision = bininfo.CommitOr("unknown")
+
 func main() {
-	version := bininfo.VersionOr("unknown")
 	if showVersion {
 		fmt.Println(version)
 		os.Exit(0)
@@ -134,6 +137,9 @@ func handlerDefault(w http.ResponseWriter, r *http.Request) {
 			<body>
 			<h1>NTP Exporter</h1>
 			<p><a href="` + metricsPath + `">Metrics</a></p>
+			<p>Version: ` + version + `</p>
+			<p>Revision: ` + revision + `</p>
+			<p>Build date: ` + buildDate + `</p>
 			</body>
 			</html>`))
 }


### PR DESCRIPTION
Adds ntp_build_info metric with labels based on bininfo
- version
- revision (git commit hash)
- build_date

Named metric build_info to be as compliant as possible with https://www.robustperception.io/exposing-the-software-version-to-prometheus/

closes #12
