### PR TITLE
Goreleaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
-# v2.4.0 (TBD)
+## v2.4.0 - TBD
 
 Changes:
 
-# v2.3.0 (2023-06-14)
+## v2.3.0 - 2023-06-14
 
 Changes:
 
-- The container image moved from Docker Hub to ghcr.io and can now be found under ``ghcr.io/sapcc/ntp_exporter:vX.X.X``
-- Add automaxprocs
+- The container image moved from Docker Hub to ghcr.io and can now be found under `ghcr.io/sapcc/ntp_exporter:vX.X.X`.
+- Add automaxprocs.
 - Update all dependencies to their current versions.
 
-# v2.2.0 (2023-04-04)
+## v2.2.0 - 2023-04-04
 
 Changes:
 
@@ -18,7 +18,7 @@ Changes:
 - Golang was updated to version 1.20.
 - Update all dependencies to their current versions.
 
-# v2.1.0 (2022-06-17)
+## v2.1.0 - 2022-06-17
 
 Changes:
 
@@ -26,19 +26,19 @@ Changes:
 - The `ntp_stratum` metric now has the label `server`, and is reported separately for each server.
 - Go got updated to version 1.18.
 
-# v2.0.2 (2022-05-04)
+## v2.0.2 - 2022-05-04
 
 Changes:
 
 - Update all dependencies to their current versions.
 
-# v2.0.1 (2021-09-24)
+## v2.0.1 - 2021-09-24
 
 Changes:
 
 - Update all dependencies to their current versions.
 
-# v2.0.0 (2020-08-04)
+## v2.0.0 - 2020-08-04
 
 **Backwards-incompatible changes:**
 
@@ -50,25 +50,25 @@ Changes:
 
 - Update all dependencies to their current versions.
 
-# v1.1.3 (2020-05-28)
+## v1.1.3 - 2020-05-28
 
 Changes:
 
 - Update all dependencies to their current versions.
 
-# v1.1.2 (2020-04-08)
+## v1.1.2 - 2020-04-08
 
 Changes:
 
 - Update all dependencies to their current versions.
 
-# v1.1.1 (2020-02-10)
+## v1.1.1 - 2020-02-10
 
 Changes:
 
 - Update all dependencies to their current versions.
 
-# v1.1.0 (2019-11-19)
+## v1.1.0 - 2019-11-19
 
 New features:
 
@@ -87,6 +87,6 @@ Changes:
 
 [alloc]: https://github.com/prometheus/prometheus/wiki/Default-port-allocations#exporters-starting-at-9100
 
-# v1.0.0 (2017-01-13)
+## v1.0.0 - 2017-01-13
 
 Initial release.

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -20,6 +20,9 @@ golang:
 golangciLint:
   createConfig: true
 
+goReleaser:
+  createConfig: true
+
 spellCheck:
   ignoreWords: ["strat"]
 
@@ -32,6 +35,8 @@ githubWorkflow:
   license:
     enabled: true
   pushContainerToGhcr:
+    enabled: true
+  release:
     enabled: true
   securityChecks:
     enabled: true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,45 @@
+# Release Guide
+
+We use [GoReleaser][goreleaser] and GitHub workflows for automating the release
+process. Follow the instructions below for creating a new release.
+
+1. Ensure local `master` branch is up to date with `origin/master`:
+
+   ```sh
+   git fetch --tags && git pull --tags
+   ```
+
+2. Ensure all checks are passing:
+
+   ```sh
+   make check
+   ```
+
+3. Update the [`CHANGELOG`](./CHANGELOG.md).
+   Make sure that the format is consistent especially the version heading.
+   We follow [semantic versioning][semver] for our releases.
+
+   You can check if the file format is correct by running [`release-info`][release-info] for the new version:
+
+   ```sh
+   go install github.com/sapcc/go-bits/tools/release-info@latest
+   release-info CHANGELOG.md X.Y.Z
+   ```
+
+   where `X.Y.Z` is the version that you are planning to release.
+
+4. Commit the updated changelog with message: `Release <version>`
+5. Create and push a new Git tag:
+
+   ```sh
+   git tag vX.Y.Z
+   git push --tags
+   ```
+
+   > [!IMPORTANT]
+   > Tags are prefixed with `v` and the GitHub release workflow is triggered for tags that match the `v[0-9]+.[0-9]+.[0-9]+` [gh-pattern].
+
+[release-info]: https://github.com/sapcc/go-bits/tree/master/tools/release-info
+[semver]: https://semver.org/spec/v2.0.0.html
+[gh-pattern]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags
+[goreleaser]: https://github.com/goreleaser/goreleaser


### PR DESCRIPTION
Do not merge before https://github.com/sapcc/go-makefile-maker/pull/122

I have updated the [`release-info`](https://github.com/sapcc/go-bits/tree/master/tools/release-info) tool so that we only need to conform to a specific version heading format. The format for the actual release notes between these headings can be arbitrary.

This will allow us to use `release-info` for all of our tools where we leverage GoReleaser GitHub workflow without having to refactor the entire changelog.