### PR TITLE
Rename high-drift query string to high_drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-## v2.7.0 - TBD
+## v2.8.0 - TBD
 
 Changes:
+
+## v2.7.0 - 2024-09-10
+
+Changes:
+- Renamed the `high-drift` query string in variable mode to `high_drift`. This makes it easies to use with Prometheus which does not accept dashes in label names.
 
 ## v2.6.1 - 2024-07-08
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ request:
 - `target`: NTP server to use
 - `protocol`: NTP protocol version (2, 3 or 4)
 - `duration`: duration of measurements in case of high drift
-- `high-drift`: High drift threshold to trigger multiple probing
+- `high_drift`: High drift threshold to trigger multiple probing
 
 For example:
 
 ```sh
-$ curl 'http://localhost:9559/metrics?target=ntp.example.com&protocol=4&duration=10s&high-drift=100ms'
+$ curl 'http://localhost:9559/metrics?target=ntp.example.com&protocol=4&duration=10s&high_drift=100ms'
 ```
 
 ## Frequently asked questions (FAQ)

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func handlerMetrics(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if u, err := time.ParseDuration(r.URL.Query().Get("high-drift")); err == nil {
+		if u, err := time.ParseDuration(r.URL.Query().Get("high_drift")); err == nil {
 			hd = u
 		} else {
 			http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
Closes #112

Prometheus does not allow dashes in labels.