### PR TITLE
Collect ntp_build_info metric even when there is a failure

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -147,11 +147,11 @@ func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 func (c Collector) Collect(ch chan<- prometheus.Metric) {
 	err := c.measure()
 
+	c.buildInfo.Collect(ch)
 	c.serverReachable.Collect(ch)
 
 	// only report data when measurement was successful
 	if err == nil {
-		c.buildInfo.Collect(ch)
 		c.drift.Collect(ch)
 		c.stratum.Collect(ch)
 		c.rtt.Collect(ch)


### PR DESCRIPTION
Closes #181

```
 ➜ ./build/ntp_exporter -ntp.server 192.168.1.1
2025/09/02 16:21:08 maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined
2025/09/02 16:21:08 starting ntp_exporter v2.8.0-108-g02a4f59
2025/09/02 16:21:08 INFO: Listening on :9559...
2025/09/02 16:21:10 ERROR: couldn't get NTP measurement: couldn't get NTP measurement: read udp 100.64.0.13:35434->192.168.1.1:123: read: connection refused
```

```
 ➜ curl 127.0.0.1:9559/metrics
# HELP ntp_build_info ntp_exporter version.
# TYPE ntp_build_info gauge
ntp_build_info{build_date="2025-09-02T14:19:50Z",revision="02a4f5926dd577e361ca0f789a56d4dc8604fd66",version="v2.8.0-108-g02a4f59"} 1
# HELP ntp_server_reachable True if the NTP server is reachable by the NTP exporter.
# TYPE ntp_server_reachable gauge
ntp_server_reachable{server="192.168.1.1"} 0
```

Afterwards lets do another release